### PR TITLE
Allow specifying counts for character sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ long.
 
 *-LENGTH*, *--length LENGTH*  
     For passwords and PINs, this option specifies the total number of
-    characters used, and defaults to 20 for passwords and 4 for PINs. For
-    passphrases, this option specifies the total number of words used, and
-    defaults to 3.
+    characters used, and defaults to 20 for passwords and 4 for PINs. When
+    used along with options `-s`, `-n`, `-u`, or `-l`, an error is emitted if
+    they would prevent the specified length from being met (i.e. `-s 20` would
+    exceed a LENGTH of 10).  For passphrases, this option specifies the total
+    number of words used, and defaults to 3.
 
 *-p*, *--passphrase*  
     Generates a passphrase using dictionary words instead of a password of
@@ -43,22 +45,25 @@ long.
 *-P*, *--pin*  
     Generates a numeric PIN.
 
-*-n*, *--numbers*  
-    For passwords, this option will force the password to include at least
-    one numeric digit. For passphrases and PINs, this option has no
+*-n [COUNT]*, *--numbers [COUNT]*  
+    For passwords, this option specifies the number of numbers to include in
+    the generated password. If no COUNT is specified, at least one number is
+    guaranteed to be included. For passphrases and PINs, this option has no
     effect.
 
 *-N*, *--no-numbers*  
-    For passwords, this option will force the password to include no
-    numbers at all. For passphrases and PINs, this options has no effect.
+    For passwords, this option forces the password to include no numbers at
+    all. For passphrases and PINs, this options has no effect.
 
-*-s*, *--symbols*  
-    For passwords, this option will force the password to include at least
-    one symbol. For passphrases and PINs, this option has no effect.
+*-s [COUNT]*, *--symbols [COUNT]*  
+    For passwords, this option specifies the number of symbols to include in
+    the generated password. If no COUNT is specified, at least one symbol is
+    guaranteed to be included. For passphrases and PINs, this option has no
+    effect.
 
 *-S*, *--no-symbols*  
-    For passwords, this option will force the password to include no
-    symbols at all. For passphrases and PINs, this option has no effect.
+    For passwords, this option forces the password to include no symbols at
+    all. For passphrases and PINs, this option has no effect.
 
 *-d CHAR*, *--delimiter CHAR*  
     For passphrases, this option is the character that is used between
@@ -71,10 +76,35 @@ long.
     temporary wordlist will be downloaded from GitHub (see WORD LISTS
     below). For passwords and PINs, this option has no effect.
 
-*-U*, *--upcase*  
-    For passphrases, this option will cause words in the passphrase to be
-    randomly UPCASED, and defaults to off. For passwords and PINs, this
-    option has no effect.
+*-u [COUNT]*, *--upcase [COUNT]*  
+    For passwords, this option specifies the number of uppercase letters to
+    include in the generated password. If no COUNT is specified, at least one
+    uppercase letter is guaranteed to be included. By default, passwords
+    include at least one uppercase character. For passphrases, this option
+    specifies the number of uppercase words to include in the generated
+    passphrase. If no COUNT is specified, at least one uppercase word is
+    guaranteed to be included. By default, passphrases do not include an
+    uppercase word. For passwords and PINs, this option has no effect.
+
+*-U*, *--no-upcase*  
+    For passwords, this option forces the password to have no uppercase
+    characters at all. For passphrases, this option forces the passphrase to
+    include no uppercase words at all. For PINs, this option has no effect.
+
+*-l [COUNT]*, *--lower [COUNT]*  
+    For passwords, this option specifies the number of lowercase characters to
+    include in the generated password. If no COUNT is supplied, at least one
+    lowercase character is guaranteed to be provided. By default passwords
+    include at least one lowercase character. For passphrases, this option
+    specifies the number of lowercase words to include in the generated
+    passphrase. If no COUNT is specified, at least one lowercase word is
+    guaranteed to be included. By default, passphrases do not include an
+    uppercase word. For PINs, this option has no effect.
+
+*-L*, *--no-lower*  
+    For passwords, this option forces the password to have no lowercase
+    characters at all. For passphrases, this option forces the passphrase to
+    include no lowercase words at all. For PINs, this option has no effect.
 
 *-m LENGTH*, *--min-word-length LENGTH*  
     For passphrases, this option will choose words in the passphrase at

--- a/bin/bashword
+++ b/bin/bashword
@@ -25,9 +25,11 @@
 # OPTIONS
 #   -[LENGTH], --length LENGTH
 #       For passwords and PINs, this option specifies the total number of
-#       characters used, and defaults to 20 for passwords and 4 for PINs. For
-#       passphrases, this option specifies the total number of words used, and
-#       defaults to 3.
+#       characters used, and defaults to 20 for passwords and 4 for PINs. When
+#       used along with options `-s`, `-n`, `-u`, or `-l`, an error is emitted
+#       if they would prevent the specified length from being met (i.e. `-s
+#       20` would exceed a LENGTH of 10). For passphrases, this option
+#       specifies the total number of words used, and defaults to 3.
 #
 #   -p, --passphrase
 #       Generates a passphrase using dictionary words instead of a password of
@@ -36,22 +38,25 @@
 #   -P, --pin
 #       Generates a numeric PIN.
 #
-#   -n, --numbers
-#       For passwords, this option will force the password to include at least
-#       one numeric digit. For passphrases and PINs, this option has no
-#       effect.
+#   -n [COUNT], --numbers [COUNT]
+#       For passwords, this option specifies the number of numbers to include
+#       in the generated password. If no COUNT is specified, at least one
+#       number is guaranteed to be included. For passphrases and PINs, this
+#       option has no effect.
 #
 #   -N, --no-numbers
-#       For passwords, this option will force the password to include no
-#       numbers at all. For passphrases and PINs, this options has no effect.
+#       For passwords, this option forces the password to include no numbers
+#       at all. For passphrases and PINs, this options has no effect.
 #
-#   -s, --symbols
-#       For passwords, this option will force the password to include at least
-#       one symbol. For passphrases and PINs, this option has no effect.
+#   -s [COUNT], --symbols [COUNT]
+#       For passwords, this option specifies the number of symbols to include
+#       in the generated password. If no COUNT is specified, at least one
+#       symbol is guaranteed to be included. For passphrases and PINs, this
+#       option has no effect.
 #
 #   -S, --no-symbols
-#       For passwords, this option will force the password to include no
-#       symbols at all. For passphrases and PINs, this option has no effect.
+#       For passwords, this option forces the password to include no symbols
+#       at all. For passphrases and PINs, this option has no effect.
 #
 #   -d CHAR, --delimiter CHAR
 #       For passphrases, this option is the character that is used between
@@ -64,10 +69,39 @@
 #       temporary wordlist will be downloaded from GitHub (see WORD LISTS
 #       below). For passwords and PINs, this option has no effect.
 #
-#   -U, --upcase
-#       For passphrases, this option will cause words in the passphrase to be
-#       randomly UPCASED, and defaults to off. For passwords and PINs, this
-#       option has no effect.
+#   -u [COUNT], --upcase [COUNT]
+#       For passwords, this option specifies the number of uppercase letters
+#       to include in the generated password. If no COUNT is specified, at
+#       least one uppercase letter is guaranteed to be included. By default,
+#       passwords include at least one uppercase character. For passphrases,
+#       this option specifies the number of uppercase words to include in the
+#       generated passphrase. If no COUNT is specified, at least one uppercase
+#       word is guaranteed to be included. By default, passphrases do not
+#       include an uppercase word. For passwords and PINs, this option has no
+#       effect.
+#
+#   -U, --no-upcase
+#       For passwords, this option forces the password to have no uppercase
+#       characters at all. For passphrases, this option forces the passphrase
+#       to include no uppercase words at all. For PINs, this option has no
+#       effect.
+#
+#   -l [COUNT], --lower [COUNT]
+#       For passwords, this option specifies the number of lowercase
+#       characters to include in the generated password. If no COUNT is
+#       supplied, at least one lowercase character is guaranteed to be
+#       provided. By default passwords include at least one lowercase
+#       character. For passphrases, this option specifies the number of
+#       lowercase words to include in the generated passphrase. If no COUNT is
+#       specified, at least one lowercase word is guaranteed to be included.
+#       By default, passphrases do not include an uppercase word. For PINs,
+#       this option has no effect.
+#
+#   -L, --no-lower
+#       For passwords, this option forces the password to have no lowercase
+#       characters at all. For passphrases, this option forces the passphrase
+#       to include no lowercase words at all. For PINs, this option has no
+#       effect.
 #
 #   -m LENGTH, --min-word-length LENGTH
 #       For passphrases, this option will choose words in the passphrase at
@@ -211,8 +245,8 @@ generate_passphrase() {
       sed -n "$lines"
     fi
   } | while read -r word; do
-      if [[ "$upcase" ]]; then
-        upcase=""
+      if [[ "${upcase//y/1}" -gt 0 ]]; then
+        upcase="$((${upcase//y/1} - 1))"
         tr '[:lower:]' '[:upper:]' <<< "$word"
       else
         tr '[:upper:]' '[:lower:]' <<< "$word"
@@ -258,46 +292,91 @@ get_char() {
 # Generates a password
 #
 # $1 - total password length
-# $2 - use numbers?
-# $3 - use symbols?
+# $2 - number of digits to use
+# $3 - number of symbols to use
+# $4 - number of uppercase letters to use
+#
+# shellcheck disable=SC2004
 generate_password() {
-  local length="$1" digits="$2" symbols="$3" i=0
+  local length="$1" digits="$2" symbols="$3" uppercase="$4" lowercase="$5" \
+    min_needed=0 i
 
   if ! [[ "$length" =~ ^[0-9]+$ ]]; then
     warn "Length must be a number!"
     return 1
-  fi
-
-  if [[ "$length" -lt 8 ]]; then
+  elif [[ "$length" -lt 8 ]]; then
     warn "Length must be at least 8 characters!"
+    return 1
+  elif [[ "$digits" != y ]] && ! [[ "$digits" =~ ^[0-9]+$ ]]; then
+    warn "Digit count must be a number!"
+    return 1
+  elif [[ "$symbols" != y ]] && ! [[ "$symbols" =~ ^[0-9]+$ ]]; then
+    warn "Symbol count must be a number!"
+    return 1
+  elif [[ "$uppercase" != y ]] && ! [[ "$uppercase" =~ ^[0-9]+$ ]]; then
+    warn "Uppercase letter count must be a number!"
+    return 1
+  elif [[ "$lowercase" != y ]] && ! [[ "$lowercase" =~ ^[0-9]+$ ]]; then
+    warn "Lowercase letter count must be a number!"
     return 1
   fi
 
   {
-    if [[ "$digits" ]]; then
+    min_needed=$((
+      ${digits//y/1} +
+      ${symbols//y/1} +
+      ${uppercase//y/1} +
+      ${lowercase//y/1}
+    ))
+
+    if [[ "$*" =~ y ]]; then
+      (( min_needed <= length ))
+    else
+      (( min_needed == length ))
+    fi
+  } || {
+    warn "Length of $length is not valid!"
+    warn
+    warn "Asked for:"
+    warn
+    warn "  - Numbers: ${digits//y/(at least 1)}"
+    warn "  - Symbols: ${symbols//y/(at least 1)}"
+    warn "  - Uppercase Letters: ${uppercase//y/(at least 1)}"
+    warn "  - Lowercase Letters: ${lowercase//y/(at least 1)}"
+    warn
+    warn "This would result in a ${min_needed} character password."
+    return 1
+  }
+
+  {
+    for (( i=0; i < ${digits//y/1}; i++ )); do
       get_char "[:digit:]"
-      i=$(( i + 1 ))
-    fi
-
-    if [[ "$symbols" ]]; then
-      get_char "[:punct:]"
-      i=$(( i + 1 ))
-    fi
-
-    get_char "[:lower:]"
-    i=$(( i + 1 ))
-
-    get_char "[:upper:]"
-    i=$(( i + 1 ))
-
-    for (( i; i < length; i++ )); do
-      # Avoid too many symbols
-      if (( i < length/2 )); then
-        get_char "[:alpha:]${digits:+[:digit:]}${symbols:+[:punct:]}"
-      else
-        get_char "[:alpha:]${digits:+[:digit:]}"
-      fi
+      length=$(( length - 1 ))
     done
+
+    for (( i=0; i < ${symbols//y/1}; i++ )); do
+      get_char "[:punct:]"
+      length=$(( length - 1 ))
+    done
+
+    for (( i=0; i < ${uppercase//y/1}; i++ )); do
+      get_char "[:upper:]"
+      length=$(( length - 1 ))
+    done
+
+    for (( i=0; i < ${lowercase//y/1}; i++ )); do
+      get_char "[:lower:]"
+      length=$(( length - 1 ))
+    done
+
+    if (( length > 0 )); then
+      get_char "$(
+        [[ "$digits" = y ]] && printf "[:digit:]"
+        [[ "$symbols" = y ]] && printf "[:punct:]"
+        [[ "$uppercase" = y ]] && printf "[:upper:]"
+        [[ "$lowercase" = y ]] && printf "[:lower:]"
+      )" "$length"
+    fi
   } | sort -R | awk '{ printf "%s", $1 }'
 }
 
@@ -316,7 +395,7 @@ generate_pin() {
 }
 
 main() {
-  local length numbers=1 symbols=1 dictionary_file upcase delimiter \
+  local length numbers=y symbols=y dictionary_file upcase lower=y delimiter \
     min_word_length max_word_length style=password count=1 i
 
   while [[ "$#" -gt 0 ]]; do
@@ -354,19 +433,53 @@ main() {
         shift
         ;;
       -n|--numbers)
-        numbers=1
+        if [[ $# -gt 1 ]] && [[ "${2:0:1}" != "-" ]]; then
+          numbers="$2"
+          shift 2
+        else
+          numbers=y
+          shift
+        fi
+        ;;
+      --numbers=*)
+        if [[ -z "${1#*=}" ]]; then
+          warn "Must specify value for '$1'"
+          return 1
+        fi
+        numbers="${1#*=}"
+        shift
+        ;;
+      -n*)
+        numbers="${1:2}"
         shift
         ;;
       -N|--no-numbers)
-        numbers=
+        numbers=0
         shift
         ;;
       -s|--symbols)
-        symbols=1
+        if [[ $# -gt 1 ]] && [[ "${2:0:1}" != "-" ]]; then
+          symbols="$2"
+          shift 2
+        else
+          symbols=y
+          shift
+        fi
+        ;;
+      --symbols=*)
+        if [[ -z "${1#*=}" ]]; then
+          warn "Must specify value for '$1'"
+          return 1
+        fi
+        symbols="${1#*=}"
+        shift
+        ;;
+      -s*)
+        symbols="${1:2}"
         shift
         ;;
       -S|--no-symbols)
-        symbols=
+        symbols=0
         shift
         ;;
       -F|--dictionary-file)
@@ -389,8 +502,54 @@ main() {
         dictionary_file="${1#*=}"
         shift
         ;;
-      -U|--upcase)
-        upcase=1
+      -u|--upcase)
+        if [[ $# -gt 1 ]] && [[ "${2:0:1}" != "-" ]]; then
+          upcase="$2"
+          shift 2
+        else
+          upcase=y
+          shift
+        fi
+        ;;
+      -u*)
+        upcase="${1:2}"
+        shift
+        ;;
+      --upcase=*)
+        if [[ -z "${1#*=}" ]]; then
+          warn "Must specify value for '$1'"
+          return 1
+        fi
+        upcase="${1#*=}"
+        shift
+        ;;
+      -U|--no-upcase)
+        upcase=0
+        shift
+        ;;
+      -l|--lower)
+        if [[ $# -gt 1 ]] && [[ "${2:0:1}" != "-" ]]; then
+          lower="$2"
+          shift 2
+        else
+          lower=y
+          shift
+        fi
+        ;;
+      --lower=*)
+        if [[ -z "${1#*=}" ]]; then
+          warn "Must specify value for '$1'"
+          return 1
+        fi
+        lower="${1#*=}"
+        shift
+        ;;
+      -l*)
+        lower="${1:2}"
+        shift
+        ;;
+      -L|--no-lower)
+        lower=0
         shift
         ;;
       -d|--delimiter)
@@ -513,7 +672,9 @@ main() {
       generate_password \
         "${length:-$DEFAULT_PASSWORD_LENGTH}" \
         "${numbers:-}" \
-        "${symbols:-}"
+        "${symbols:-}" \
+        "${upcase:-y}" \
+        "${lower:-}"
     elif [[ "$style" = passphrase ]]; then
       generate_passphrase \
         "${length:-$DEFAULT_PASSPHRASE_WORD_COUNT}" \

--- a/doc/man/bashword.1.md
+++ b/doc/man/bashword.1.md
@@ -23,9 +23,11 @@ long.
 
 *-LENGTH*, *--length LENGTH*  
     For passwords and PINs, this option specifies the total number of
-    characters used, and defaults to 20 for passwords and 4 for PINs. For
-    passphrases, this option specifies the total number of words used, and
-    defaults to 3.
+    characters used, and defaults to 20 for passwords and 4 for PINs. When
+    used along with options `-s`, `-n`, `-u`, or `-l`, an error is emitted if
+    they would prevent the specified length from being met (i.e. `-s 20` would
+    exceed a LENGTH of 10).  For passphrases, this option specifies the total
+    number of words used, and defaults to 3.
 
 *-p*, *--passphrase*  
     Generates a passphrase using dictionary words instead of a password of
@@ -34,22 +36,25 @@ long.
 *-P*, *--pin*  
     Generates a numeric PIN.
 
-*-n*, *--numbers*  
-    For passwords, this option will force the password to include at least
-    one numeric digit. For passphrases and PINs, this option has no
+*-n [COUNT]*, *--numbers [COUNT]*  
+    For passwords, this option specifies the number of numbers to include in
+    the generated password. If no COUNT is specified, at least one number is
+    guaranteed to be included. For passphrases and PINs, this option has no
     effect.
 
 *-N*, *--no-numbers*  
-    For passwords, this option will force the password to include no
-    numbers at all. For passphrases and PINs, this options has no effect.
+    For passwords, this option forces the password to include no numbers at
+    all. For passphrases and PINs, this options has no effect.
 
-*-s*, *--symbols*  
-    For passwords, this option will force the password to include at least
-    one symbol. For passphrases and PINs, this option has no effect.
+*-s [COUNT]*, *--symbols [COUNT]*  
+    For passwords, this option specifies the number of symbols to include in
+    the generated password. If no COUNT is specified, at least one symbol is
+    guaranteed to be included. For passphrases and PINs, this option has no
+    effect.
 
 *-S*, *--no-symbols*  
-    For passwords, this option will force the password to include no
-    symbols at all. For passphrases and PINs, this option has no effect.
+    For passwords, this option forces the password to include no symbols at
+    all. For passphrases and PINs, this option has no effect.
 
 *-d CHAR*, *--delimiter CHAR*  
     For passphrases, this option is the character that is used between
@@ -62,10 +67,35 @@ long.
     temporary wordlist will be downloaded from GitHub (see WORD LISTS
     below). For passwords and PINs, this option has no effect.
 
-*-U*, *--upcase*  
-    For passphrases, this option will cause words in the passphrase to be
-    randomly UPCASED, and defaults to off. For passwords and PINs, this
-    option has no effect.
+*-u [COUNT]*, *--upcase [COUNT]*  
+    For passwords, this option specifies the number of uppercase letters to
+    include in the generated password. If no COUNT is specified, at least one
+    uppercase letter is guaranteed to be included. By default, passwords
+    include at least one uppercase character. For passphrases, this option
+    specifies the number of uppercase words to include in the generated
+    passphrase. If no COUNT is specified, at least one uppercase word is
+    guaranteed to be included. By default, passphrases do not include an
+    uppercase word. For passwords and PINs, this option has no effect.
+
+*-U*, *--no-upcase*  
+    For passwords, this option forces the password to have no uppercase
+    characters at all. For passphrases, this option forces the passphrase to
+    include no uppercase words at all. For PINs, this option has no effect.
+
+*-l [COUNT]*, *--lower [COUNT]*  
+    For passwords, this option specifies the number of lowercase characters to
+    include in the generated password. If no COUNT is supplied, at least one
+    lowercase character is guaranteed to be provided. By default passwords
+    include at least one lowercase character. For passphrases, this option
+    specifies the number of lowercase words to include in the generated
+    passphrase. If no COUNT is specified, at least one lowercase word is
+    guaranteed to be included. By default, passphrases do not include an
+    uppercase word. For PINs, this option has no effect.
+
+*-L*, *--no-lower*  
+    For passwords, this option forces the password to have no lowercase
+    characters at all. For passphrases, this option forces the passphrase to
+    include no lowercase words at all. For PINs, this option has no effect.
 
 *-m LENGTH*, *--min-word-length LENGTH*  
     For passphrases, this option will choose words in the passphrase at

--- a/share/man/man1/bashword.1
+++ b/share/man/man1/bashword.1
@@ -31,9 +31,11 @@ long\.
 .TP
 \fI\-LENGTH\fP, \fI\-\-length LENGTH\fP
 For passwords and PINs, this option specifies the total number of
-characters used, and defaults to 20 for passwords and 4 for PINs\. For
-passphrases, this option specifies the total number of words used, and
-defaults to 3\.
+characters used, and defaults to 20 for passwords and 4 for PINs\. When
+used along with options \fB-s\fR, \fB-n\fR, \fB-u\fR, or \fB-l\fR, an error is emitted if
+they would prevent the specified length from being met (i\.e\. \fB-s 20\fR would
+exceed a LENGTH of 10)\.  For passphrases, this option specifies the total
+number of words used, and defaults to 3\.
 .LP
 .TP
 \fI\-p\fP, \fI\-\-passphrase\fP
@@ -45,25 +47,28 @@ random characters\.
 Generates a numeric PIN\.
 .LP
 .TP
-\fI\-n\fP, \fI\-\-numbers\fP
-For passwords, this option will force the password to include at least
-one numeric digit\. For passphrases and PINs, this option has no
+\fI\-n \[lB]COUNT\[rB]\fP, \fI\-\-numbers \[lB]COUNT\[rB]\fP
+For passwords, this option specifies the number of numbers to include in
+the generated password\. If no COUNT is specified, at least one number is
+guaranteed to be included\. For passphrases and PINs, this option has no
 effect\.
 .LP
 .TP
 \fI\-N\fP, \fI\-\-no\-numbers\fP
-For passwords, this option will force the password to include no
-numbers at all\. For passphrases and PINs, this options has no effect\.
+For passwords, this option forces the password to include no numbers at
+all\. For passphrases and PINs, this options has no effect\.
 .LP
 .TP
-\fI\-s\fP, \fI\-\-symbols\fP
-For passwords, this option will force the password to include at least
-one symbol\. For passphrases and PINs, this option has no effect\.
+\fI\-s \[lB]COUNT\[rB]\fP, \fI\-\-symbols \[lB]COUNT\[rB]\fP
+For passwords, this option specifies the number of symbols to include in
+the generated password\. If no COUNT is specified, at least one symbol is
+guaranteed to be included\. For passphrases and PINs, this option has no
+effect\.
 .LP
 .TP
 \fI\-S\fP, \fI\-\-no\-symbols\fP
-For passwords, this option will force the password to include no
-symbols at all\. For passphrases and PINs, this option has no effect\.
+For passwords, this option forces the password to include no symbols at
+all\. For passphrases and PINs, this option has no effect\.
 .LP
 .TP
 \fI\-d CHAR\fP, \fI\-\-delimiter CHAR\fP
@@ -79,10 +84,38 @@ temporary wordlist will be downloaded from GitHub (see WORD LISTS
 below)\. For passwords and PINs, this option has no effect\.
 .LP
 .TP
-\fI\-U\fP, \fI\-\-upcase\fP
-For passphrases, this option will cause words in the passphrase to be
-randomly UPCASED, and defaults to off\. For passwords and PINs, this
-option has no effect\.
+\fI\-u \[lB]COUNT\[rB]\fP, \fI\-\-upcase \[lB]COUNT\[rB]\fP
+For passwords, this option specifies the number of uppercase letters to
+include in the generated password\. If no COUNT is specified, at least one
+uppercase letter is guaranteed to be included\. By default, passwords
+include at least one uppercase character\. For passphrases, this option
+specifies the number of uppercase words to include in the generated
+passphrase\. If no COUNT is specified, at least one uppercase word is
+guaranteed to be included\. By default, passphrases do not include an
+uppercase word\. For passwords and PINs, this option has no effect\.
+.LP
+.TP
+\fI\-U\fP, \fI\-\-no\-upcase\fP
+For passwords, this option forces the password to have no uppercase
+characters at all\. For passphrases, this option forces the passphrase to
+include no uppercase words at all\. For PINs, this option has no effect\.
+.LP
+.TP
+\fI\-l \[lB]COUNT\[rB]\fP, \fI\-\-lower \[lB]COUNT\[rB]\fP
+For passwords, this option specifies the number of lowercase characters to
+include in the generated password\. If no COUNT is supplied, at least one
+lowercase character is guaranteed to be provided\. By default passwords
+include at least one lowercase character\. For passphrases, this option
+specifies the number of lowercase words to include in the generated
+passphrase\. If no COUNT is specified, at least one lowercase word is
+guaranteed to be included\. By default, passphrases do not include an
+uppercase word\. For PINs, this option has no effect\.
+.LP
+.TP
+\fI\-L\fP, \fI\-\-no\-lower\fP
+For passwords, this option forces the password to have no lowercase
+characters at all\. For passphrases, this option forces the passphrase to
+include no lowercase words at all\. For PINs, this option has no effect\.
 .LP
 .TP
 \fI\-m LENGTH\fP, \fI\-\-min\-word\-length LENGTH\fP

--- a/test/test_bashword.bats
+++ b/test/test_bashword.bats
@@ -23,22 +23,48 @@ load test_helper
   _assert_results
 }
 
-@test "bashword --symbols: generates a password with at least one symbol" {
+@test "bashword --length LENGTH: errors if options prevent given LENGTH" {
+  run bashword -30 -s1 -n1 -u1 -l1
+  assert_failure
+
+  run bashword -30 -S -N -U -L
+  assert_failure
+
+  run bashword -30 -s10 -n10 -u10 -l
+  assert_failure
+
+  run bashword -10 -s1 -u8 -l1 -n
+  assert_failure
+}
+
+@test "bashword --symbols: generates a password with symbols" {
   _assert_results() {
-    assert_output --regexp "[[:punct:]]"
+    assert_characters "[[:punct:]]" "$1"
     assert_success
   }
 
   run bashword --symbols
   _assert_results
 
+  run bashword --symbols 5
+  _assert_results 5
+
+  run bashword --symbols=6
+  _assert_results 6
+
   run bashword -s
   _assert_results
+
+  run bashword -s3
+  _assert_results 3
+
+  run bashword -s 4
+  _assert_results 4
 }
 
 @test "bashword --numbers: generates a password with at least one number" {
   _assert_results() {
-    assert_output --regexp "[[:digit:]]"
+    assert_characters "[[:digit:]]" "$1"
     assert_success
   }
 
@@ -46,6 +72,69 @@ load test_helper
   _assert_results
 
   run bashword -n
+  _assert_results
+
+  run bashword -n3
+  _assert_results 3
+
+  run bashword -n 4
+  _assert_results 4
+
+  run bashword --numbers 5
+  _assert_results 5
+
+  run bashword --numbers=6
+  _assert_results 6
+}
+
+@test "bashword --lower: generates a password with at least one lowercase character" {
+  _assert_results() {
+    assert_characters "[[:lower:]]" "$1"
+    assert_success
+  }
+
+  run bashword --lower
+  _assert_results
+
+  run bashword -l
+  _assert_results
+
+  run bashword -l3
+  _assert_results 3
+
+  run bashword -l 4
+  _assert_results 4
+
+  run bashword --lower 5
+  _assert_results 5
+
+  run bashword --lower=6
+  _assert_results 6
+}
+
+@test "bashword --upcase: generates a password with at least one uppercase character" {
+  _assert_results() {
+    assert_characters "[[:upper:]]" "$1"
+    assert_success
+  }
+
+  run bashword --upcase
+  _assert_results
+
+  run bashword -u
+  _assert_results
+
+  run bashword -u3
+  _assert_results 3
+
+  run bashword -u 4
+  _assert_results 4
+
+  run bashword --upcase 5
+  _assert_results 5
+
+  run bashword --upcase=6
+  _assert_results 6
 }
 
 @test "bashword --no-symbols: generates a password with no symbols" {
@@ -59,6 +148,12 @@ load test_helper
 
   run bashword -S
   _assert_results
+
+  run bashword -s0
+  _assert_results
+
+  run bashword --symbols=0
+  _assert_results
 }
 
 @test "bashword --no-numbers: generates a password with no numbers" {
@@ -71,6 +166,51 @@ load test_helper
   _assert_results
 
   run bashword -N
+  _assert_results
+
+  run bashword -n0
+  _assert_results
+
+  run bashword --numbers=0
+  _assert_results
+}
+
+
+@test "bashword --no-upcase: generates a password with no uppercase characters" {
+  _assert_results() {
+    assert_output --regexp "^[^[:upper:]]+$"
+    assert_success
+  }
+
+  run bashword --no-upcase
+  _assert_results
+
+  run bashword -U
+  _assert_results
+
+  run bashword -u0
+  _assert_results
+
+  run bashword --upcase=0
+  _assert_results
+}
+
+@test "bashword --no-lower: generates a password with no lowercase characters" {
+  _assert_results() {
+    assert_output --regexp "^[^[:lower:]]+$"
+    assert_success
+  }
+
+  run bashword --no-lower
+  _assert_results
+
+  run bashword -L
+  _assert_results
+
+  run bashword -l0
+  _assert_results
+
+  run bashword --lower=0
   _assert_results
 }
 
@@ -101,12 +241,11 @@ load test_helper
 
   run bashword -c3
   _assert_results
-
 }
 
 @test "bashword --passphrase: generates a passphrase with 3 5-8 character words by default" {
   _assert_results() {
-    assert_output --regexp "^[[:lower:]]{5,8}-[[:lower:]]{5,8}-[[:lower:]]{5,8}$"
+    assert_output --regexp "^[[:alpha:]]{5,8}-[[:alpha:]]{5,8}-[[:alpha:]]{5,8}$"
     assert_success
   }
 
@@ -119,7 +258,7 @@ load test_helper
 
 @test "bashword --passphrase --length LENGTH: generates a passphrase with the specified number of words" {
   _assert_results() {
-    assert_output --regexp "^[[:lower:]]{5,8}-[[:lower:]]{5,8}-[[:lower:]]{5,8}-[[:lower:]]{5,8}$"
+    assert_output --regexp "^[[:alpha:]]{5,8}-[[:alpha:]]{5,8}-[[:alpha:]]{5,8}-[[:alpha:]]{5,8}$"
     assert_success
   }
 
@@ -138,7 +277,7 @@ load test_helper
 
 @test "bashword --passphrase --word-length LENGTH: generates a passphrase with words of the exact length specified" {
   _assert_results() {
-    assert_output --regexp "^[[:lower:]]{6}-[[:lower:]]{6}-[[:lower:]]{6}$"
+    assert_output --regexp "^[[:alpha:]]{6}-[[:alpha:]]{6}-[[:alpha:]]{6}$"
     assert_success
   }
 
@@ -157,7 +296,7 @@ load test_helper
 
 @test "bashword --passphrase --max-word-length LENGTH generates a passphrase with words of the given max lengths" {
   _assert_results() {
-    assert_output --regexp "^[[:lower:]]{1,10}-[[:lower:]]{1,10}-[[:lower:]]{1,10}$"
+    assert_output --regexp "^[[:alpha:]]{1,10}-[[:alpha:]]{1,10}-[[:alpha:]]{1,10}$"
     assert_success
   }
 
@@ -176,7 +315,7 @@ load test_helper
 
 @test "bashword --passphrase --min-word-length LENGTH generates a passphrase with words of the given min lengths" {
   _assert_results() {
-    assert_output --regexp "^[[:lower:]]{5,}-[[:lower:]]{5,}-[[:lower:]]{5,}$"
+    assert_output --regexp "^[[:alpha:]]{5,}-[[:alpha:]]{5,}-[[:alpha:]]{5,}$"
     assert_success
   }
 
@@ -203,7 +342,19 @@ load test_helper
   run bashword --passphrase --upcase
   _assert_results
 
-  run bashword --passphrase -U
+  run bashword --passphrase -u
+  _assert_results
+
+  run bashword --passphrase --upcase=1
+  _assert_results
+
+  run bashword --passphrase -u1
+  _assert_results
+
+  run bashword --passphrase --upcase 1
+  _assert_results
+
+  run bashword --passphrase -u 1
   _assert_results
 }
 
@@ -231,15 +382,15 @@ load test_helper
     assert_equal "${#lines[*]}" 3
 
     echo "${lines[0]}" |
-      grep -E -q "^[[:lower:]]{5,10}-[[:lower:]]{5,10}-[[:lower:]]{5,10}$" ||
+      grep -E -q "^[[:alpha:]]{5,10}-[[:alpha:]]{5,10}-[[:alpha:]]{5,10}$" ||
       fail "line 0: ${lines[0]} didn't match expression"
 
     echo "${lines[1]}" |
-      grep -E -q "^[[:lower:]]{5,10}-[[:lower:]]{5,10}-[[:lower:]]{5,10}$" ||
+      grep -E -q "^[[:alpha:]]{5,10}-[[:alpha:]]{5,10}-[[:alpha:]]{5,10}$" ||
       fail "line 1: ${lines[1]} didn't match expression"
 
     echo "${lines[2]}" |
-      grep -E -q "^[[:lower:]]{5,10}-[[:lower:]]{5,10}-[[:lower:]]{5,10}$" ||
+      grep -E -q "^[[:alpha:]]{5,10}-[[:alpha:]]{5,10}-[[:alpha:]]{5,10}$" ||
       fail "line 1: ${lines[2]} didn't match expression"
 
     assert_success

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -10,3 +10,15 @@ setup() {
   # make executables in bin/ and test/bin visible to PATH
   PATH="$DIR/../bin:$DIR/../test/bin:$PATH"
 }
+
+# shellcheck disable=SC2154
+assert_characters() {
+  local charset="$1" count="$2"
+
+  assert_output --regexp "$charset"
+
+  if [[ "$count" ]]; then
+    assert_equal "$count" \
+      "$(grep -E -o "$charset" <<< "$output" | awk 'END { print NR }')"
+  fi
+}


### PR DESCRIPTION
Now counts for specific character sets can be specified, i.e.:

- `--upcase [LENGTH]`: Include LENGTH uppercase characters (or guarantee at least 1 if no LENGTH supplied)
- `--lower [LENGTH]`: Include LENGTH lowercase characters (or guarantee at least 1 if no LENGTH supplied)
- `--symbols [LENGTH]`: Include LENGTH symbol characters (or guarantee at least 1 if no LENGTH supplied)
- `--numbers [LENGTH]`: Include LENGTH number characters (or guarantee at least 1 if no LENGTH supplied)

Or exclude certain character sets:

- `--no-upcase`: Include no uppercase characters at all
- `--no-lower`: Include no lowercase characters at all
- `--no-symbols`: Include no symbol characters at all
- `--no-numbers`: Include no number characters at all

If these options would prevent the overall password length (i.e. the `--length LENGTH` option) being met, an error is emitted.