### PR TITLE
Fix pure bash sort for passphrase word selection

### DIFF
--- a/bin/bashword
+++ b/bin/bashword
@@ -243,9 +243,9 @@ generate_passphrase() {
 
         if [[ "$number" -eq 0 ]] || [[ ";$lines" = *";${number}p;"* ]]; then
           i=$(( i-- ))
+        else
+          lines="${lines}${number}p;"
         fi
-
-        lines="${lines}${number}p;"
       done
 
       sed -n "$lines"

--- a/bin/bashword
+++ b/bin/bashword
@@ -225,7 +225,7 @@ generate_passphrase() {
 
   dict="$(get_word_list "$dict")"
 
-  line_max="$(grep -c -e "^.\{$length_min,${length_max-}\}$" "$dict")"
+  line_max="$(grep -c -e "^.\{$length_min,${length_max-}\}$" "$dict" || true)"
 
   if [[ "$words" -gt "$line_max" ]]; then
     warn "not enough words"
@@ -236,10 +236,16 @@ generate_passphrase() {
     if type shuf &> /dev/null; then
       shuf "-n$words"
     else
-      local lines="" i
+      local lines="" number i
 
       for (( i=0; i < words; i++ )); do
-        lines="${lines}$(( ((RANDOM << 15 | RANDOM) << 15 | RANDOM ) % (line_max + 1) ))p;"
+        number="$(( ((RANDOM << 15 | RANDOM) << 15 | RANDOM ) % (line_max + 1) ))"
+
+        if [[ "$number" -eq 0 ]] || [[ ";$lines" = *";${number}p;"* ]]; then
+          i=$(( i-- ))
+        fi
+
+        lines="${lines}${number}p;"
       done
 
       sed -n "$lines"


### PR DESCRIPTION
Previously there were two bugs in how words were selected if `shuf` was
not found

1. It could sometimes choose 0, `0p` in `sed` prints nothing
2. Words could be reused