### PR TITLE
Strip Windows line endings from wordlist

### DIFF
--- a/bin/bashword
+++ b/bin/bashword
@@ -225,14 +225,14 @@ generate_passphrase() {
 
   dict="$(get_word_list "$dict")"
 
-  line_max="$(tr -d '\r' < "$dict" | grep -c -e "^.\{$length_min,${length_max-}\}" || true)"
+  line_max="$(tr -d $'\r' < "$dict" | grep -c -e "^.\{$length_min,${length_max-}\}$" || true)"
 
   if [[ "$words" -gt "$line_max" ]]; then
     warn "not enough words"
     return 1
   fi
 
-  tr -d '\r' < "$dict" | grep -e "^.\{$length_min,${length_max-}\}$" | {
+  tr -d $'\r' < "$dict" | grep -e "^.\{$length_min,${length_max-}\}$" | {
     if type shuf &> /dev/null; then
       shuf "-n$words"
     else

--- a/bin/bashword
+++ b/bin/bashword
@@ -232,7 +232,7 @@ generate_passphrase() {
     return 1
   fi
 
-  grep -e "^.\{$length_min,${length_max-}\}$" "$dict" | {
+  tr -d '\r' < "$dict" | grep -e "^.\{$length_min,${length_max-}\}$" | {
     if type shuf &> /dev/null; then
       shuf "-n$words"
     else

--- a/bin/bashword
+++ b/bin/bashword
@@ -225,7 +225,7 @@ generate_passphrase() {
 
   dict="$(get_word_list "$dict")"
 
-  line_max="$(grep -c -e "^.\{$length_min,${length_max-}\}$" "$dict" || true)"
+  line_max="$(tr -d '\r' < "$dict" | grep -c -e "^.\{$length_min,${length_max-}\}" || true)"
 
   if [[ "$words" -gt "$line_max" ]]; then
     warn "not enough words"

--- a/test/fixtures/words
+++ b/test/fixtures/words
@@ -1,0 +1,10 @@
+aira
+Sobralia
+flamen
+pickable
+unvetoed
+beguess
+retackle
+trayful
+keener
+heaver

--- a/test/fixtures/words-windows
+++ b/test/fixtures/words-windows
@@ -1,0 +1,10 @@
+aira
+Sobralia
+flamen
+pickable
+unvetoed
+beguess
+retackle
+trayful
+keener
+heaver

--- a/test/test_bashword.bats
+++ b/test/test_bashword.bats
@@ -409,6 +409,28 @@ load test_helper
   _assert_results
 }
 
+@test "bashword --passphrase --dictionary-file FILE works with a custom word list" {
+  _assert_results() {
+    assert_output --regexp "^[[:alpha:]]{5,8}-[[:alpha:]]{5,8}-[[:alpha:]]{5,8}$"
+    assert_success
+  }
+
+  run bashword --passphrase --dictionary-file test/fixtures/words
+  _assert_results
+
+  run bashword --passphrase --dictionary-file=test/fixtures/words
+  _assert_results
+
+  run bashword --passphrase -Ftest/fixtures/words
+  _assert_results
+
+  run bashword --passphrase -F test/fixtures/words
+  _assert_results
+
+  run bashword --passphrase -F test/fixtures/words-windows
+  _assert_results
+}
+
 @test "bashword --pin: generates a numeric PIN 4 characters long by default" {
   _assert_results() {
     assert_output --regexp "^[0-9]{4}$"


### PR DESCRIPTION
This fixes failures like the one at https://github.com/itspriddle/bashword/runs/3515493064?check_suite_focus=true 