### PR TITLE
Call get_char multiple times

### DIFF
--- a/bin/bashword
+++ b/bin/bashword
@@ -411,14 +411,14 @@ generate_password() {
       length=$(( length - 1 ))
     done
 
-    if (( length > 0 )); then
+    for (( i=0; i < length; i++ )); do
       get_char "$(
         [[ "$digits" = y ]] && printf "[:digit:]"
         [[ "$symbols" = y ]] && printf "[:punct:]"
         [[ "$uppercase" = y ]] && printf "[:upper:]"
         [[ "$lowercase" = y ]] && printf "[:lower:]"
-      )" "$length"
-    fi
+      )"
+    done
   } | sort -R | awk '{ printf "%s", $1 }'
 }
 


### PR DESCRIPTION
Previously, this was doing something like:

```
  {
    get_char "[:upper"] # => U 321
    get_char "[:lower"] # => l 51
    get_char "[:punct"] # => $ 9402
    get_char "..." 5    # => asdf1 4321
  } | sort -R
```

This means that the "asdf1" chars will always be output in that order,
and the "U", "l", and "S" characters can be randomly placed before or
after "asdf1".

The intention was for each character "U", "l", "S", "a", "s", "d", "f",
"1" to be randomized as:

```
  {
    get_char "[:upper"] # => U 321
    get_char "[:lower"] # => l 51
    get_char "[:punct"] # => $ 9402
    get_char "..." 5    # => a 5934
    get_char "..." 5    # => s 12
    get_char "..." 5    # => d 901
    get_char "..." 5    # => f 4930
    get_char "..." 5    # => 1 432
  } | sort -R
```

This is a bit slower since it results in more reads to `/dev/urandom`,
but it provides more randomness.